### PR TITLE
Fix Attack() called multiple times

### DIFF
--- a/Assets/Scripts/MoveCharacter.cs
+++ b/Assets/Scripts/MoveCharacter.cs
@@ -76,7 +76,7 @@ public class MoveCharacter : MonoBehaviour {
     void InputCharacter() {
         direction = Vector2.zero;
 
-        if (Input.GetKey(KeyCode.Space)) {
+        if (Input.GetKeyDown(KeyCode.Space)) {
             Attack();
         }
 


### PR DESCRIPTION
Hello
I thought cause that Attack() called multiple times when pressing SpaceKey.

Then, I changed input method below .
Please make sure.

```Input.GetKey(space)``` => ```Input.GetKeyDown(space)```